### PR TITLE
Add Fields to Mautic models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ spec/dummy/.sass-cache
 Gemfile.lock
 .idea/*
 coverage
+/.ctags
+/tags

--- a/app/models/mautic/contact.rb
+++ b/app/models/mautic/contact.rb
@@ -11,5 +11,18 @@ module Mautic
       "#{firstname} #{lastname}"
     end
 
+    def assign_attributes(source = {})
+      data = {}
+
+      fields = source['fields']
+      if fields.nil?
+        data = source
+      elsif fields['all'].nil?
+        data = fields.map { |_group, pairs| pairs.map { |key, attrs| [key, attrs['value']] } }.flatten.to_h
+      else
+        data = fields['all']
+      end
+      super data
+    end
   end
 end

--- a/app/models/mautic/field.rb
+++ b/app/models/mautic/field.rb
@@ -1,0 +1,7 @@
+module Mautic
+  class Field < Model
+    def self.endpoint
+      'fields/contact'
+    end
+  end
+end

--- a/lib/mautic/model.rb
+++ b/lib/mautic/model.rb
@@ -107,29 +107,14 @@ module Mautic
       self.class.endpoint
     end
 
-    def assign_attributes(source = nil)
-      @mautic_attributes = []
-      source ||= {}
-      data = {}
+    def assign_attributes(source = {})
+      @mautic_attributes ||= []
 
-      if (fields = source['fields'])
-        if fields['all']
-          @mautic_attributes = fields['all'].collect do |key, value|
-            data[key] = value
-            Attribute.new(alias: key, value: value)
-          end
-        else
-          fields.each do |_group, pairs|
-            pairs.each do |key, attrs|
-              @mautic_attributes << (a = Attribute.new(attrs))
-              data[key] = a.value
-            end
-          end
-        end
-      elsif source
-        data = source
+      source.each do |key, value|
+        @mautic_attributes << Attribute.new(key: key, value: value)
       end
-      self.attributes = data
+
+      self.attributes = source
     end
 
   end

--- a/lib/mautic/model.rb
+++ b/lib/mautic/model.rb
@@ -33,6 +33,12 @@ module Mautic
         Proxy.new(connection, endpoint)
       end
 
+      def all(connection)
+        @connection = connection
+        json = @connection.request(:get, "api/#{endpoint}")
+        json[endpoint].map { |j| self.new(@connection, j) }
+      end
+
     end
 
     def initialize(connection, hash=nil)


### PR DESCRIPTION
To add fields to Mautic models, the following changes were made:

- abstract some methods of `Mautic::Model` so that it can be applied to other models than existing ones.
- add class methods in analogous to that of `ActiveRecord`. (e.g. `Model.find`.)
- some improvements